### PR TITLE
fix(scanner): expand user environment variables in DPROJ paths (#27)

### DIFF
--- a/src/DX.Comply.ProjectScanner.pas
+++ b/src/DX.Comply.ProjectScanner.pas
@@ -34,6 +34,7 @@ interface
 
 uses
   System.SysUtils,
+  System.StrUtils,
   System.Classes,
   System.IOUtils,
   System.RegularExpressions,
@@ -1058,6 +1059,41 @@ end;
 function TProjectScanner.NormalizePath(const APath, AProjectName: string): string;
 var
   LPath: string;
+
+  // Expands any remaining $(VarName) placeholders by consulting Windows
+  // environment variables. Delphi's "User System Overrides" propagate to the
+  // build via environment variables, so this resolves project-specific tokens
+  // such as $(DVER) — issue #27.
+  function ExpandEnvironmentTokens(const AInput: string): string;
+  var
+    LIdx, LStart, LEnd: Integer;
+    LName, LValue: string;
+  begin
+    Result := AInput;
+    LIdx := 1;
+    while LIdx < Length(Result) do
+    begin
+      LStart := PosEx('$(', Result, LIdx);
+      if LStart = 0 then
+        Break;
+      LEnd := PosEx(')', Result, LStart + 2);
+      if LEnd = 0 then
+        Break;
+      LName := Copy(Result, LStart + 2, LEnd - LStart - 2);
+      LValue := GetEnvironmentVariable(LName);
+      if LValue <> '' then
+      begin
+        Result := Copy(Result, 1, LStart - 1) + LValue +
+          Copy(Result, LEnd + 1, MaxInt);
+        // Continue searching after the substituted value
+        LIdx := LStart + Length(LValue);
+      end
+      else
+        // Unknown token — leave it intact and advance past it
+        LIdx := LEnd + 1;
+    end;
+  end;
+
 begin
   LPath := APath;
   // Standard MSBuild variables
@@ -1066,6 +1102,9 @@ begin
   LPath := StringReplace(LPath, '$(Configuration)', FCurrentConfig, [rfIgnoreCase, rfReplaceAll]);
   LPath := StringReplace(LPath, '$(MSBuildProjectName)', AProjectName, [rfIgnoreCase, rfReplaceAll]);
   LPath := StringReplace(LPath, '$(ProjectName)', AProjectName, [rfIgnoreCase, rfReplaceAll]);
+  // Resolve user-defined $(VarName) placeholders against environment variables.
+  if Pos('$(', LPath) > 0 then
+    LPath := ExpandEnvironmentTokens(LPath);
   // Normalize path separators
   LPath := StringReplace(LPath, '/', '\', [rfReplaceAll]);
   // Remove trailing backslash

--- a/src/DX.Comply.ProjectScanner.pas
+++ b/src/DX.Comply.ProjectScanner.pas
@@ -1081,6 +1081,12 @@ var
         Break;
       LName := Copy(Result, LStart + 2, LEnd - LStart - 2);
       LValue := GetEnvironmentVariable(LName);
+      // Limitation: GetEnvironmentVariable returns '' both for an undefined
+      // variable AND for one that is defined but empty. We cannot
+      // distinguish the two cases without the lower-level Win32 API.
+      // Treating both as "leave the token intact" is the safer choice —
+      // substituting an empty string would silently collapse path
+      // segments and produce invalid paths. See issue #27.
       if LValue <> '' then
       begin
         Result := Copy(Result, 1, LStart - 1) + LValue +
@@ -1089,7 +1095,7 @@ var
         LIdx := LStart + Length(LValue);
       end
       else
-        // Unknown token — leave it intact and advance past it
+        // Unknown or empty token — leave it intact and advance past it
         LIdx := LEnd + 1;
     end;
   end;

--- a/tests/DX.Comply.Tests.ProjectScanner.pas
+++ b/tests/DX.Comply.Tests.ProjectScanner.pas
@@ -23,6 +23,7 @@ interface
 uses
   System.SysUtils,
   System.IOUtils,
+  Winapi.Windows,
   DUnitX.TestFramework,
   DX.Comply.ProjectScanner,
   DX.Comply.Engine.Intf;
@@ -153,6 +154,13 @@ type
     /// </summary>
     [Test]
     procedure Scan_NamedPlatformEntry_iOSDevice64_NoTargetedPlatformsWarning;
+
+    /// <summary>
+    /// $(VarName) tokens in DPROJ paths must be expanded from the
+    /// process environment (issue #27).
+    /// </summary>
+    [Test]
+    procedure Scan_DprojWithEnvVarInOutputDir_ExpandsEnvVar;
   end;
 
 implementation
@@ -638,6 +646,60 @@ begin
   finally
     TFile.Delete(LTempDproj);
     TDirectory.Delete(LTempDir);
+  end;
+end;
+
+// ---- Environment variable expansion (regression #27) -----------------------
+
+procedure TProjectScannerTests.Scan_DprojWithEnvVarInOutputDir_ExpandsEnvVar;
+const
+  cEnvVarName  = 'DXCOMPLY_TEST_OUTPUT';
+  cEnvVarValue = 'env_expanded_segment';
+var
+  LTempDir, LTempDproj: string;
+  LProjectInfo: TProjectInfo;
+  LScanner: IProjectScanner;
+  LDproj: string;
+begin
+  // Set a process-level env var so NormalizePath has something to resolve.
+  Winapi.Windows.SetEnvironmentVariable(PChar(cEnvVarName), PChar(cEnvVarValue));
+  try
+    LDproj :=
+      '<?xml version="1.0" encoding="utf-8"?>' + sLineBreak +
+      '<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">' + sLineBreak +
+      '  <PropertyGroup>' + sLineBreak +
+      '    <MainSource>EnvVarApp.dpr</MainSource>' + sLineBreak +
+      '    <ProjectGuid>{00000000-0000-0000-0000-000000000099}</ProjectGuid>' + sLineBreak +
+      '  </PropertyGroup>' + sLineBreak +
+      '  <PropertyGroup Condition="''$(Config)''==''Release''">' + sLineBreak +
+      '    <DCC_ExeOutput>.\bin\$(' + cEnvVarName + ')</DCC_ExeOutput>' + sLineBreak +
+      '  </PropertyGroup>' + sLineBreak +
+      '</Project>';
+
+    LTempDir := TPath.Combine(TPath.GetTempPath, 'DXComplyTest_EnvVar');
+    ForceDirectories(LTempDir);
+    LTempDproj := TPath.Combine(LTempDir, 'EnvVarApp.dproj');
+    try
+      TFile.WriteAllText(LTempDproj, LDproj, TEncoding.UTF8);
+      LScanner := TProjectScanner.Create;
+      LProjectInfo := LScanner.Scan(LTempDproj, 'Win32', 'Release');
+      try
+        Assert.IsTrue(Pos(cEnvVarValue, LProjectInfo.OutputDir) > 0,
+          'OutputDir must contain the expanded env var value but was: ' +
+          LProjectInfo.OutputDir);
+        Assert.IsTrue(Pos('$(' + cEnvVarName + ')', LProjectInfo.OutputDir) = 0,
+          'OutputDir must not contain the unresolved $(VarName) token');
+      finally
+        LProjectInfo.Free;
+      end;
+    finally
+      if TFile.Exists(LTempDproj) then
+        TFile.Delete(LTempDproj);
+      if TDirectory.Exists(LTempDir) then
+        TDirectory.Delete(LTempDir);
+    end;
+  finally
+    Winapi.Windows.SetEnvironmentVariable(PChar(cEnvVarName), nil);
   end;
 end;
 

--- a/tests/DX.Comply.Tests.ProjectScanner.pas
+++ b/tests/DX.Comply.Tests.ProjectScanner.pas
@@ -664,6 +664,10 @@ begin
   // Set a process-level env var so NormalizePath has something to resolve.
   Winapi.Windows.SetEnvironmentVariable(PChar(cEnvVarName), PChar(cEnvVarValue));
   try
+    // Use the Delphi 2007 legacy condition format the scanner recognizes:
+    // '$(Configuration)|$(Platform)'=='Release|Win32'. Modern .dproj files
+    // use $(Cfg_N) keys instead, but the legacy form is sufficient to
+    // exercise the env-var expansion path.
     LDproj :=
       '<?xml version="1.0" encoding="utf-8"?>' + sLineBreak +
       '<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">' + sLineBreak +
@@ -671,7 +675,7 @@ begin
       '    <MainSource>EnvVarApp.dpr</MainSource>' + sLineBreak +
       '    <ProjectGuid>{00000000-0000-0000-0000-000000000099}</ProjectGuid>' + sLineBreak +
       '  </PropertyGroup>' + sLineBreak +
-      '  <PropertyGroup Condition="''$(Config)''==''Release''">' + sLineBreak +
+      '  <PropertyGroup Condition="''$(Configuration)|$(Platform)''==''Release|Win32''">' + sLineBreak +
       '    <DCC_ExeOutput>.\bin\$(' + cEnvVarName + ')</DCC_ExeOutput>' + sLineBreak +
       '  </PropertyGroup>' + sLineBreak +
       '</Project>';


### PR DESCRIPTION
## Summary

Fixes #27 — Delphi's "User System Overrides" propagate to the build via Windows environment variables and can be referenced inside DPROJ output paths with the same `\$(VarName)` syntax as MSBuild placeholders. The path normalizer only resolved a fixed set of well-known tokens (`\$(Platform)`, `\$(Config)`, etc.), so paths referencing user-defined variables such as `\$(DVER)` were left in their raw form and the expected MAP file could not be located.

`NormalizePath` now substitutes any remaining `\$(VarName)` placeholder with the corresponding environment variable. Unknown tokens are left untouched so callers still see them in warning messages.

## Files changed
- `src/DX.Comply.ProjectScanner.pas` — added `ExpandEnvironmentTokens` inner function called from `NormalizePath`; added `System.StrUtils` to interface uses for `PosEx`.

## Test plan
- [ ] Set a user env var (e.g. `set DVER=D37`) and run DX.Comply against a project whose `DCC_ExeOutput` uses `Output\\\$(DVER)\\Release` — verify the MAP file is found.
- [ ] Standard MSBuild tokens (`\$(Platform)`, `\$(Config)`) continue to work.
- [ ] An unknown token (e.g. `\$(NOT_SET)`) remains in the path; existing warnings still surface it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)