### PR TITLE
feat(cli): add --include-platform-in-output flag (#25)

### DIFF
--- a/src/CLI/DX.Comply.CLI.Options.pas
+++ b/src/CLI/DX.Comply.CLI.Options.pas
@@ -50,6 +50,8 @@ type
     FNoPause: Boolean;
     FMapDir: string;
     FNoCompositionEvidence: Boolean;
+    FIncludePlatformInOutput: Boolean;
+    FOutputExplicit: Boolean;
     FParseError: string;
     /// <summary>
     /// Converts a format string token to the corresponding TSbomFormat enum
@@ -94,6 +96,12 @@ type
     property NoPause: Boolean read FNoPause;
     property MapDir: string read FMapDir;
     property NoCompositionEvidence: Boolean read FNoCompositionEvidence;
+    /// <summary>
+    /// When True (and --output is not supplied), the default bom.json
+    /// filename is decorated with the selected platform and configuration
+    /// (e.g. bom.Win64.Release.json) — issue #25.
+    /// </summary>
+    property IncludePlatformInOutput: Boolean read FIncludePlatformInOutput;
     property ParseError: string read FParseError;
   end;
 
@@ -186,6 +194,12 @@ begin
       Continue;
     end;
 
+    if LArg = '--include-platform-in-output' then
+    begin
+      FIncludePlatformInOutput := True;
+      Continue;
+    end;
+
     if LArg.StartsWith('--') then
     begin
       // Split into key and value at the first '='
@@ -205,7 +219,10 @@ begin
       else if LKey = 'format' then
         FFormat := ParseFormat(LValue)
       else if LKey = 'output' then
-        FOutput := LValue
+      begin
+        FOutput := LValue;
+        FOutputExplicit := True;
+      end
       else if LKey = 'platform' then
         FPlatform := LValue
       else if LKey = 'config-name' then
@@ -281,6 +298,9 @@ begin
   Writeln('  --exclude=<pattern>           File exclude pattern (repeatable)');
   Writeln('  --map-dir=<path>              Directory containing the pre-built MAP file');
   Writeln('  --no-composition-evidence     Omit source/DCU units from SBOM (binary-only)');
+  Writeln('  --include-platform-in-output  Append <Platform>.<Config> to the default');
+  Writeln('                                output filename (e.g. bom.Win64.Release.json)');
+  Writeln('                                — ignored when --output is supplied');
   Writeln('  --ci                          CI mode: use .dxcomply.json config file');
   Writeln('  --config=<path>               Path to .dxcomply.json (default: .dxcomply.json)');
   Writeln('  --help, -h                    Show this help');
@@ -302,9 +322,22 @@ end;
 // ---------------------------------------------------------------------------
 
 function TCliOptions.ToSbomConfig: TSbomConfig;
+var
+  LDir, LName, LExt: string;
 begin
   Result := TSbomConfig.Default;
   Result.OutputPath      := FOutput;
+
+  // When --include-platform-in-output is set and --output was not supplied,
+  // decorate the default filename with the selected platform/config so that
+  // multi-platform builds do not overwrite one another. Issue #25.
+  if FIncludePlatformInOutput and not FOutputExplicit and (FOutput <> '') then
+  begin
+    LDir  := ExtractFilePath(FOutput);
+    LExt  := ExtractFileExt(FOutput);
+    LName := ChangeFileExt(ExtractFileName(FOutput), '');
+    Result.OutputPath := LDir + LName + '.' + FPlatform + '.' + FConfiguration + LExt;
+  end;
   Result.Format          := FFormat;
   Result.Platform        := FPlatform;
   Result.Configuration   := FConfiguration;

--- a/src/CLI/DX.Comply.CLI.Options.pas
+++ b/src/CLI/DX.Comply.CLI.Options.pas
@@ -61,6 +61,12 @@ type
     /// <summary>Appends AValue to the given dynamic string array.</summary>
     procedure AppendPattern(var APatterns: TArray<string>; const AValue: string);
   public
+    /// <summary>
+    /// Strips characters that could enable path traversal or directory
+    /// injection when a value is interpolated into a filename. Keeps only
+    /// ASCII letters, digits, hyphen and underscore. Exposed for testing.
+    /// </summary>
+    class function SanitizeForFilename(const AValue: string): string; static;
     constructor Create;
     /// <summary>
     /// Parses the process ParamStr array and populates all properties.
@@ -321,9 +327,19 @@ end;
 // ToSbomConfig
 // ---------------------------------------------------------------------------
 
+class function TCliOptions.SanitizeForFilename(const AValue: string): string;
+var
+  LChar: Char;
+begin
+  Result := '';
+  for LChar in AValue do
+    if CharInSet(LChar, ['A'..'Z', 'a'..'z', '0'..'9', '-', '_']) then
+      Result := Result + LChar;
+end;
+
 function TCliOptions.ToSbomConfig: TSbomConfig;
 var
-  LDir, LName, LExt: string;
+  LDir, LName, LExt, LSafePlatform, LSafeConfig: string;
 begin
   Result := TSbomConfig.Default;
   Result.OutputPath      := FOutput;
@@ -331,12 +347,18 @@ begin
   // When --include-platform-in-output is set and --output was not supplied,
   // decorate the default filename with the selected platform/config so that
   // multi-platform builds do not overwrite one another. Issue #25.
+  //
+  // FPlatform and FConfiguration are sanitized before interpolation: a
+  // user-supplied value such as "..\\..\\evil" or "Win32/etc" would otherwise
+  // escape the intended output directory or break path semantics.
   if FIncludePlatformInOutput and not FOutputExplicit and (FOutput <> '') then
   begin
-    LDir  := ExtractFilePath(FOutput);
-    LExt  := ExtractFileExt(FOutput);
-    LName := ChangeFileExt(ExtractFileName(FOutput), '');
-    Result.OutputPath := LDir + LName + '.' + FPlatform + '.' + FConfiguration + LExt;
+    LDir          := ExtractFilePath(FOutput);
+    LExt          := ExtractFileExt(FOutput);
+    LName         := ChangeFileExt(ExtractFileName(FOutput), '');
+    LSafePlatform := TCliOptions.SanitizeForFilename(FPlatform);
+    LSafeConfig   := TCliOptions.SanitizeForFilename(FConfiguration);
+    Result.OutputPath := LDir + LName + '.' + LSafePlatform + '.' + LSafeConfig + LExt;
   end;
   Result.Format          := FFormat;
   Result.Platform        := FPlatform;

--- a/tests/DX.Comply.Tests.CLI.Options.pas
+++ b/tests/DX.Comply.Tests.CLI.Options.pas
@@ -62,6 +62,24 @@ type
     /// <summary>ToSbomConfig must propagate the default configuration.</summary>
     [Test]
     procedure ToSbomConfig_Default_ConfigurationIsRelease;
+
+    // ---- Filename sanitisation (issue #25 security follow-up) ---------------
+
+    /// <summary>Backslashes must be stripped from filename segments.</summary>
+    [Test]
+    procedure SanitizeForFilename_StripsBackslash;
+
+    /// <summary>Forward slashes must be stripped from filename segments.</summary>
+    [Test]
+    procedure SanitizeForFilename_StripsForwardSlash;
+
+    /// <summary>Parent-directory '..' sequences must be reduced to safe chars.</summary>
+    [Test]
+    procedure SanitizeForFilename_StripsDoubleDot;
+
+    /// <summary>Alphanumeric, hyphen and underscore must be preserved.</summary>
+    [Test]
+    procedure SanitizeForFilename_PreservesAllowedChars;
   end;
 
 implementation
@@ -154,6 +172,32 @@ begin
   finally
     LOptions.Free;
   end;
+end;
+
+// ---- Filename sanitisation --------------------------------------------------
+
+procedure TCliOptionsTests.SanitizeForFilename_StripsBackslash;
+begin
+  Assert.AreEqual('Win32', TCliOptions.SanitizeForFilename('Win32\..\evil'),
+    'Backslashes and dots must be stripped — only safe chars survive');
+end;
+
+procedure TCliOptionsTests.SanitizeForFilename_StripsForwardSlash;
+begin
+  Assert.AreEqual('Win32etc', TCliOptions.SanitizeForFilename('Win32/etc'),
+    'Forward slashes must be stripped');
+end;
+
+procedure TCliOptionsTests.SanitizeForFilename_StripsDoubleDot;
+begin
+  Assert.AreEqual('abc', TCliOptions.SanitizeForFilename('..abc..'),
+    'Period characters must be stripped');
+end;
+
+procedure TCliOptionsTests.SanitizeForFilename_PreservesAllowedChars;
+begin
+  Assert.AreEqual('Release-1_0', TCliOptions.SanitizeForFilename('Release-1_0'),
+    'Alphanumeric, hyphen and underscore must be preserved');
 end;
 
 initialization

--- a/tests/DX.Comply.Tests.CLI.Options.pas
+++ b/tests/DX.Comply.Tests.CLI.Options.pas
@@ -178,7 +178,10 @@ end;
 
 procedure TCliOptionsTests.SanitizeForFilename_StripsBackslash;
 begin
-  Assert.AreEqual('Win32', TCliOptions.SanitizeForFilename('Win32\..\evil'),
+  // SanitizeForFilename is a strip-only whitelist: every non-safe char
+  // is removed but the remaining safe chars from later segments are
+  // preserved (same semantics as SanitizeForFilename_StripsForwardSlash).
+  Assert.AreEqual('Win32evil', TCliOptions.SanitizeForFilename('Win32\..\evil'),
     'Backslashes and dots must be stripped — only safe chars survive');
 end;
 


### PR DESCRIPTION
## Summary

Implements #25 — multi-platform builds overwrote `bom.json` between targets. This is the non-breaking opt-in variant suggested in the issue: a new `--include-platform-in-output` flag appends `.<Platform>.<Config>` to the default base filename, producing e.g. `bom.Win64.Release.json`.

* Decoration is suppressed when `--output` is supplied so explicit user paths are never rewritten.
* Companion reports (`bom.report.md` / `.html`) are derived from the SBOM output path, so they automatically inherit the same suffix.
* Default behaviour is unchanged.

## Files changed
- `src/CLI/DX.Comply.CLI.Options.pas`

## Test plan
- [ ] Run dxcomply with `--platform=Win64 --config-name=Release --include-platform-in-output` and verify `bom.Win64.Release.json` (plus `bom.Win64.Release.report.html` if reports are enabled).
- [ ] Run with `--include-platform-in-output --output=custom.json` and verify the output is `custom.json` (no suffix).
- [ ] Help text shows the new flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)