### PR TITLE
fix(engine): detect DLLs referenced via consts and GetModuleHandle (#24)

### DIFF
--- a/src/DX.Comply.Engine.pas
+++ b/src/DX.Comply.Engine.pas
@@ -554,6 +554,8 @@ var
     end;
   end;
 
+var
+  LGlobalConstMap: TDictionary<string, string>;
 begin
   LDllNames := TList<string>.Create;
   LLines := TStringList.Create;
@@ -561,6 +563,15 @@ begin
   // per-unit so the same const identifier in two different units does not
   // collide — issue #24.
   LConstMap := TDictionary<string, string>.Create;
+  // Maps "const_name" (lower-case, unqualified) -> resolved file name. Used
+  // as a project-wide fallback when an identifier-form loader call cannot be
+  // resolved within the calling unit — typical for 3rd-party libraries that
+  // split DLL-name constants into a separate "OpenSSL_Consts.pas" unit and
+  // call GetModuleHandle/LoadLibrary from a sibling "OpenSSL_Wrapper.pas".
+  // If two units declare the same const name with different values, the last
+  // one scanned wins (acceptable trade-off vs. parsing the uses clause).
+  // Issue #24 follow-up.
+  LGlobalConstMap := TDictionary<string, string>.Create;
   try
     // Patterns:
     //   external 'filename.dll'  (with optional delayed)
@@ -604,9 +615,14 @@ begin
 
         LRegExMatch := LRegExConstDll.Match(LLine);
         if LRegExMatch.Success then
+        begin
           LConstMap.AddOrSetValue(
             LUnitName + '.' + LowerCase(LRegExMatch.Groups[1].Value),
             LRegExMatch.Groups[2].Value);
+          LGlobalConstMap.AddOrSetValue(
+            LowerCase(LRegExMatch.Groups[1].Value),
+            LRegExMatch.Groups[2].Value);
+        end;
       end;
     end;
 
@@ -631,6 +647,12 @@ begin
           else
             LLookupKey := LUnitName + '.' + LIdent;
           if LConstMap.TryGetValue(LLookupKey, LResolved) then
+            AddDllName(LResolved)
+          else if (Pos('.', LIdent) = 0) and
+                  LGlobalConstMap.TryGetValue(LIdent, LResolved) then
+            // Fall back to a project-wide lookup so consts declared in a
+            // separate "OpenSSL_Consts.pas"-style unit and referenced from a
+            // sibling wrapper unit still resolve. Issue #24 follow-up.
             AddDllName(LResolved);
         end;
       end;
@@ -638,6 +660,7 @@ begin
 
     Result := LDllNames.ToArray;
   finally
+    LGlobalConstMap.Free;
     LConstMap.Free;
     LLines.Free;
     LDllNames.Free;

--- a/src/DX.Comply.Engine.pas
+++ b/src/DX.Comply.Engine.pas
@@ -161,6 +161,15 @@ type
       const AArtefacts: TArtefactList);
   public
     /// <summary>
+    /// Scans the supplied .pas files for external DLL references — string
+    /// literals in 'external' or LoadLibrary/GetModuleHandle calls, plus
+    /// identifier-form calls that are resolved against a per-unit const map.
+    /// Returns lower-cased, de-duplicated DLL/BPL file names. Public for
+    /// testability — issue #24.
+    /// </summary>
+    class function ScanPasFilesForDllReferences(
+      const APasFilePaths: TArray<string>): TArray<string>; static;
+    /// <summary>
     /// Creates a new TDxComplyGenerator instance.
     /// </summary>
     constructor Create; overload;
@@ -448,33 +457,13 @@ procedure TDxComplyGenerator.AddExternalDllReferencesToArtefacts(
   const AArtefacts: TArtefactList);
 var
   LArtefact: TArtefactInfo;
-  LDllNames: TList<string>;
-  LDllName: string;
   LPasFiles: TList<string>;
-  LFilePath, LLine, LMatch, LIdent: string;
-  LLines: TStringList;
-  LRegExExternal, LRegExLoadLib, LRegExLoadLibIdent, LRegExConstDll: TRegEx;
-  LRegExMatch: TMatch;
+  LDllNames: TArray<string>;
+  LDllName, LFilePath: string;
   LResolvedUnit: TResolvedUnitInfo;
-  LConstMap: TDictionary<string, string>;
-  LResolved: string;
   I: Integer;
-
-  procedure AddDllName(const AName: string);
-  begin
-    if AName = '' then
-      Exit;
-    if not LDllNames.Contains(LowerCase(AName)) then
-      LDllNames.Add(LowerCase(AName));
-  end;
-
 begin
-  LDllNames := TList<string>.Create;
   LPasFiles := TList<string>.Create;
-  LLines := TStringList.Create;
-  // Maps identifier (lower-case) -> resolved file name for simple const
-  // declarations such as: const LIBEAY_DLL_NAME = 'libeay32.dll'; — issue #24.
-  LConstMap := TDictionary<string, string>.Create;
   try
     // Collect all .pas files from explicit unit references
     if Assigned(AProjectInfo.ExplicitUnitReferences) then
@@ -504,87 +493,7 @@ begin
           LPasFiles.Add(LFilePath);
       end;
 
-    // Patterns:
-    //   external 'filename.dll'  (with optional delayed)
-    //   LoadLibrary('filename.dll')  /  LoadLibraryEx  /  SafeLoadLibrary  /
-    //   GetModuleHandle('filename.dll')
-    //   const NAME = 'filename.dll'; — captured separately so identifier-form
-    //     calls (e.g. LoadLibrary(LIBEAY_DLL_NAME)) can be resolved — issue #24.
-    LRegExExternal := TRegEx.Create(
-      'external\s+''([^'']+\.(dll|bpl))''', [roIgnoreCase]);
-    LRegExLoadLib := TRegEx.Create(
-      '(?:LoadLibrary|LoadLibraryEx|LoadLibraryA|LoadLibraryW|SafeLoadLibrary|GetModuleHandle|GetModuleHandleA|GetModuleHandleW|LoadPackage)\s*\(\s*''([^'']+\.(dll|bpl))''',
-      [roIgnoreCase]);
-    // Same calls but with an identifier argument that we resolve via the
-    // const map.  Skips quoted forms (already covered by LRegExLoadLib).
-    LRegExLoadLibIdent := TRegEx.Create(
-      '(?:LoadLibrary|LoadLibraryEx|LoadLibraryA|LoadLibraryW|SafeLoadLibrary|GetModuleHandle|GetModuleHandleA|GetModuleHandleW|LoadPackage)\s*\(\s*([A-Za-z_][A-Za-z0-9_\.]*)\s*[,)]',
-      [roIgnoreCase]);
-    LRegExConstDll := TRegEx.Create(
-      '\b([A-Za-z_][A-Za-z0-9_]*)\s*(?::[^=]*)?=\s*''([^'']+\.(?:dll|bpl))''',
-      [roIgnoreCase]);
-
-    // First pass: collect literal references AND build the const-name map.
-    for LFilePath in LPasFiles do
-    begin
-      try
-        LLines.LoadFromFile(LFilePath, TEncoding.UTF8);
-      except
-        try
-          LLines.LoadFromFile(LFilePath);
-        except
-          Continue;
-        end;
-      end;
-
-      for I := 0 to LLines.Count - 1 do
-      begin
-        LLine := LLines[I];
-
-        LRegExMatch := LRegExExternal.Match(LLine);
-        if LRegExMatch.Success then
-          AddDllName(LRegExMatch.Groups[1].Value);
-
-        LRegExMatch := LRegExLoadLib.Match(LLine);
-        if LRegExMatch.Success then
-          AddDllName(LRegExMatch.Groups[1].Value);
-
-        // Record  CONST_NAME = 'file.dll'  so later lookups can resolve it.
-        LRegExMatch := LRegExConstDll.Match(LLine);
-        if LRegExMatch.Success then
-          LConstMap.AddOrSetValue(
-            LowerCase(LRegExMatch.Groups[1].Value),
-            LRegExMatch.Groups[2].Value);
-      end;
-    end;
-
-    // Second pass: resolve identifier-form LoadLibrary/GetModuleHandle calls
-    // against the const map.  Done after the const map is fully populated so
-    // forward references inside the same unit also resolve.
-    for LFilePath in LPasFiles do
-    begin
-      try
-        LLines.LoadFromFile(LFilePath, TEncoding.UTF8);
-      except
-        try
-          LLines.LoadFromFile(LFilePath);
-        except
-          Continue;
-        end;
-      end;
-
-      for I := 0 to LLines.Count - 1 do
-      begin
-        LLine := LLines[I];
-        LRegExMatch := LRegExLoadLibIdent.Match(LLine);
-        if LRegExMatch.Success then
-        begin
-          LIdent := LRegExMatch.Groups[1].Value;
-          if LConstMap.TryGetValue(LowerCase(LIdent), LResolved) then
-            AddDllName(LResolved);
-        end;
-      end;
-    end;
+    LDllNames := ScanPasFilesForDllReferences(LPasFiles.ToArray);
 
     // Add discovered DLLs as artefacts
     for LDllName in LDllNames do
@@ -602,9 +511,135 @@ begin
       AArtefacts.Add(LArtefact);
     end;
   finally
+    LPasFiles.Free;
+  end;
+end;
+
+class function TDxComplyGenerator.ScanPasFilesForDllReferences(
+  const APasFilePaths: TArray<string>): TArray<string>;
+var
+  LDllNames: TList<string>;
+  LLines: TStringList;
+  LConstMap: TDictionary<string, string>;
+  LRegExExternal, LRegExLoadLib, LRegExLoadLibIdent, LRegExConstDll: TRegEx;
+  LRegExMatch: TMatch;
+  LFilePath, LLine, LIdent, LUnitName, LLookupKey, LResolved: string;
+  I: Integer;
+
+  procedure AddDllName(const AName: string);
+  begin
+    if AName = '' then
+      Exit;
+    if not LDllNames.Contains(LowerCase(AName)) then
+      LDllNames.Add(LowerCase(AName));
+  end;
+
+  function UnitNameOf(const AFilePath: string): string;
+  begin
+    Result := LowerCase(TPath.GetFileNameWithoutExtension(AFilePath));
+  end;
+
+  function LoadFileLines(const APath: string): Boolean;
+  begin
+    try
+      LLines.LoadFromFile(APath, TEncoding.UTF8);
+      Exit(True);
+    except
+      try
+        LLines.LoadFromFile(APath);
+        Exit(True);
+      except
+        Exit(False);
+      end;
+    end;
+  end;
+
+begin
+  LDllNames := TList<string>.Create;
+  LLines := TStringList.Create;
+  // Maps "unitname.const_name" (lower-case) -> resolved file name. Scoped
+  // per-unit so the same const identifier in two different units does not
+  // collide — issue #24.
+  LConstMap := TDictionary<string, string>.Create;
+  try
+    // Patterns:
+    //   external 'filename.dll'  (with optional delayed)
+    //   LoadLibrary('filename.dll') / LoadLibraryEx / SafeLoadLibrary /
+    //     GetModuleHandle('filename.dll') / LoadPackage
+    //   const NAME = 'filename.dll'; — captured separately so identifier-form
+    //     calls (e.g. LoadLibrary(LIBEAY_DLL_NAME)) can be resolved.
+    LRegExExternal := TRegEx.Create(
+      'external\s+''([^'']+\.(dll|bpl))''', [roIgnoreCase]);
+    LRegExLoadLib := TRegEx.Create(
+      '(?:LoadLibrary|LoadLibraryEx|LoadLibraryA|LoadLibraryW|SafeLoadLibrary|GetModuleHandle|GetModuleHandleA|GetModuleHandleW|LoadPackage)\s*\(\s*''([^'']+\.(dll|bpl))''',
+      [roIgnoreCase]);
+    LRegExLoadLibIdent := TRegEx.Create(
+      '(?:LoadLibrary|LoadLibraryEx|LoadLibraryA|LoadLibraryW|SafeLoadLibrary|GetModuleHandle|GetModuleHandleA|GetModuleHandleW|LoadPackage)\s*\(\s*([A-Za-z_][A-Za-z0-9_\.]*)\s*[,)]',
+      [roIgnoreCase]);
+    // Only match real const declarations: identifier starts the line
+    // (after whitespace), optional ': type', '=', single-quoted file name,
+    // then ';'.  Comparisons like `if X = 'foo.dll' then` do not end in
+    // ';' on the comparison, so they will not match.
+    LRegExConstDll := TRegEx.Create(
+      '^\s*([A-Za-z_][A-Za-z0-9_]*)\s*(?::\s*[A-Za-z_][A-Za-z0-9_]*\s*)?=\s*''([^'']+\.(?:dll|bpl))''\s*;',
+      [roIgnoreCase]);
+
+    // First pass: collect literal references AND build the const-name map.
+    for LFilePath in APasFilePaths do
+    begin
+      if not LoadFileLines(LFilePath) then
+        Continue;
+      LUnitName := UnitNameOf(LFilePath);
+      for I := 0 to LLines.Count - 1 do
+      begin
+        LLine := LLines[I];
+
+        LRegExMatch := LRegExExternal.Match(LLine);
+        if LRegExMatch.Success then
+          AddDllName(LRegExMatch.Groups[1].Value);
+
+        LRegExMatch := LRegExLoadLib.Match(LLine);
+        if LRegExMatch.Success then
+          AddDllName(LRegExMatch.Groups[1].Value);
+
+        LRegExMatch := LRegExConstDll.Match(LLine);
+        if LRegExMatch.Success then
+          LConstMap.AddOrSetValue(
+            LUnitName + '.' + LowerCase(LRegExMatch.Groups[1].Value),
+            LRegExMatch.Groups[2].Value);
+      end;
+    end;
+
+    // Second pass: resolve identifier-form calls against the const map.
+    for LFilePath in APasFilePaths do
+    begin
+      if not LoadFileLines(LFilePath) then
+        Continue;
+      LUnitName := UnitNameOf(LFilePath);
+      for I := 0 to LLines.Count - 1 do
+      begin
+        LLine := LLines[I];
+        LRegExMatch := LRegExLoadLibIdent.Match(LLine);
+        if LRegExMatch.Success then
+        begin
+          LIdent := LowerCase(LRegExMatch.Groups[1].Value);
+          // Already qualified (Other.IDENT) — use as-is.  Otherwise look up
+          // within the current unit only — cross-unit lookups would need
+          // uses-clause information that this scanner does not have.
+          if Pos('.', LIdent) > 0 then
+            LLookupKey := LIdent
+          else
+            LLookupKey := LUnitName + '.' + LIdent;
+          if LConstMap.TryGetValue(LLookupKey, LResolved) then
+            AddDllName(LResolved);
+        end;
+      end;
+    end;
+
+    Result := LDllNames.ToArray;
+  finally
     LConstMap.Free;
     LLines.Free;
-    LPasFiles.Free;
     LDllNames.Free;
   end;
 end;

--- a/src/DX.Comply.Engine.pas
+++ b/src/DX.Comply.Engine.pas
@@ -451,16 +451,30 @@ var
   LDllNames: TList<string>;
   LDllName: string;
   LPasFiles: TList<string>;
-  LFilePath, LLine, LMatch: string;
+  LFilePath, LLine, LMatch, LIdent: string;
   LLines: TStringList;
-  LRegExExternal, LRegExLoadLib: TRegEx;
+  LRegExExternal, LRegExLoadLib, LRegExLoadLibIdent, LRegExConstDll: TRegEx;
   LRegExMatch: TMatch;
   LResolvedUnit: TResolvedUnitInfo;
+  LConstMap: TDictionary<string, string>;
+  LResolved: string;
   I: Integer;
+
+  procedure AddDllName(const AName: string);
+  begin
+    if AName = '' then
+      Exit;
+    if not LDllNames.Contains(LowerCase(AName)) then
+      LDllNames.Add(LowerCase(AName));
+  end;
+
 begin
   LDllNames := TList<string>.Create;
   LPasFiles := TList<string>.Create;
   LLines := TStringList.Create;
+  // Maps identifier (lower-case) -> resolved file name for simple const
+  // declarations such as: const LIBEAY_DLL_NAME = 'libeay32.dll'; — issue #24.
+  LConstMap := TDictionary<string, string>.Create;
   try
     // Collect all .pas files from explicit unit references
     if Assigned(AProjectInfo.ExplicitUnitReferences) then
@@ -492,13 +506,25 @@ begin
 
     // Patterns:
     //   external 'filename.dll'  (with optional delayed)
-    //   LoadLibrary('filename.dll')  /  LoadLibraryEx  /  SafeLoadLibrary
+    //   LoadLibrary('filename.dll')  /  LoadLibraryEx  /  SafeLoadLibrary  /
+    //   GetModuleHandle('filename.dll')
+    //   const NAME = 'filename.dll'; — captured separately so identifier-form
+    //     calls (e.g. LoadLibrary(LIBEAY_DLL_NAME)) can be resolved — issue #24.
     LRegExExternal := TRegEx.Create(
       'external\s+''([^'']+\.(dll|bpl))''', [roIgnoreCase]);
     LRegExLoadLib := TRegEx.Create(
-      '(?:LoadLibrary|LoadLibraryEx|SafeLoadLibrary)\s*\(\s*''([^'']+\.(dll|bpl))''',
+      '(?:LoadLibrary|LoadLibraryEx|LoadLibraryA|LoadLibraryW|SafeLoadLibrary|GetModuleHandle|GetModuleHandleA|GetModuleHandleW|LoadPackage)\s*\(\s*''([^'']+\.(dll|bpl))''',
+      [roIgnoreCase]);
+    // Same calls but with an identifier argument that we resolve via the
+    // const map.  Skips quoted forms (already covered by LRegExLoadLib).
+    LRegExLoadLibIdent := TRegEx.Create(
+      '(?:LoadLibrary|LoadLibraryEx|LoadLibraryA|LoadLibraryW|SafeLoadLibrary|GetModuleHandle|GetModuleHandleA|GetModuleHandleW|LoadPackage)\s*\(\s*([A-Za-z_][A-Za-z0-9_\.]*)\s*[,)]',
+      [roIgnoreCase]);
+    LRegExConstDll := TRegEx.Create(
+      '\b([A-Za-z_][A-Za-z0-9_]*)\s*(?::[^=]*)?=\s*''([^'']+\.(?:dll|bpl))''',
       [roIgnoreCase]);
 
+    // First pass: collect literal references AND build the const-name map.
     for LFilePath in LPasFiles do
     begin
       try
@@ -517,18 +543,45 @@ begin
 
         LRegExMatch := LRegExExternal.Match(LLine);
         if LRegExMatch.Success then
-        begin
-          LMatch := LRegExMatch.Groups[1].Value;
-          if not LDllNames.Contains(LowerCase(LMatch)) then
-            LDllNames.Add(LowerCase(LMatch));
-        end;
+          AddDllName(LRegExMatch.Groups[1].Value);
 
         LRegExMatch := LRegExLoadLib.Match(LLine);
         if LRegExMatch.Success then
+          AddDllName(LRegExMatch.Groups[1].Value);
+
+        // Record  CONST_NAME = 'file.dll'  so later lookups can resolve it.
+        LRegExMatch := LRegExConstDll.Match(LLine);
+        if LRegExMatch.Success then
+          LConstMap.AddOrSetValue(
+            LowerCase(LRegExMatch.Groups[1].Value),
+            LRegExMatch.Groups[2].Value);
+      end;
+    end;
+
+    // Second pass: resolve identifier-form LoadLibrary/GetModuleHandle calls
+    // against the const map.  Done after the const map is fully populated so
+    // forward references inside the same unit also resolve.
+    for LFilePath in LPasFiles do
+    begin
+      try
+        LLines.LoadFromFile(LFilePath, TEncoding.UTF8);
+      except
+        try
+          LLines.LoadFromFile(LFilePath);
+        except
+          Continue;
+        end;
+      end;
+
+      for I := 0 to LLines.Count - 1 do
+      begin
+        LLine := LLines[I];
+        LRegExMatch := LRegExLoadLibIdent.Match(LLine);
+        if LRegExMatch.Success then
         begin
-          LMatch := LRegExMatch.Groups[1].Value;
-          if not LDllNames.Contains(LowerCase(LMatch)) then
-            LDllNames.Add(LowerCase(LMatch));
+          LIdent := LRegExMatch.Groups[1].Value;
+          if LConstMap.TryGetValue(LowerCase(LIdent), LResolved) then
+            AddDllName(LResolved);
         end;
       end;
     end;
@@ -549,6 +602,7 @@ begin
       AArtefacts.Add(LArtefact);
     end;
   finally
+    LConstMap.Free;
     LLines.Free;
     LPasFiles.Free;
     LDllNames.Free;

--- a/tests/DX.Comply.Tests.Engine.pas
+++ b/tests/DX.Comply.Tests.Engine.pas
@@ -187,6 +187,14 @@ type
     /// <summary>A comparison like `if X = 'foo.dll'` must NOT be parsed as a const.</summary>
     [Test]
     procedure ScanPasFiles_ComparisonExpression_NotTreatedAsConst;
+
+    /// <summary>
+    /// const declared in unit A, LoadLibrary called in unit B referencing the
+    /// same identifier (typical 3rd-party OpenSSL/Indy pattern) must still
+    /// resolve. Issue #24, user-reported gap after #36 preview build.
+    /// </summary>
+    [Test]
+    procedure ScanPasFiles_ConstInOtherUnit_ResolvesViaGlobalFallback;
   end;
 
 implementation
@@ -965,6 +973,45 @@ begin
   Assert.IsTrue(TArray.IndexOf<string>(LDllNames, 'foo.dll') < 0,
     '`if X = ''foo.dll''` must NOT be parsed as a const declaration; ' +
     'foo.dll should not appear in detected DLLs');
+end;
+
+procedure TEngineTests.ScanPasFiles_ConstInOtherUnit_ResolvesViaGlobalFallback;
+var
+  LConstsUnit, LCallerUnit: string;
+  LDllNames: TArray<string>;
+const
+  // Mirrors AlexSTHfg's reported pattern: 3rd-party libraries declare DLL
+  // names in a separate consts unit and load them in another wrapper unit.
+  cConstsSource =
+    'unit OpenSSL_Consts;'#13#10 +
+    'interface'#13#10 +
+    'const'#13#10 +
+    '  LIBEAY_DLL_NAME = ''libeay32.dll'';'#13#10 +
+    'implementation'#13#10 +
+    'end.';
+  cCallerSource =
+    'unit OpenSSL_Wrapper;'#13#10 +
+    'interface'#13#10 +
+    'implementation'#13#10 +
+    'uses Windows, OpenSSL_Consts;'#13#10 +
+    'procedure DoIt;'#13#10 +
+    'var H: NativeUInt;'#13#10 +
+    'begin'#13#10 +
+    '  H := GetModuleHandle(LIBEAY_DLL_NAME);'#13#10 +
+    'end;'#13#10 +
+    'end.';
+begin
+  LConstsUnit := TPath.Combine(FTempDir, 'OpenSSL_Consts.pas');
+  LCallerUnit := TPath.Combine(FTempDir, 'OpenSSL_Wrapper.pas');
+  TFile.WriteAllText(LConstsUnit, cConstsSource, TEncoding.UTF8);
+  TFile.WriteAllText(LCallerUnit, cCallerSource, TEncoding.UTF8);
+
+  LDllNames := TDxComplyGenerator.ScanPasFilesForDllReferences(
+    TArray<string>.Create(LConstsUnit, LCallerUnit));
+
+  Assert.IsTrue(TArray.IndexOf<string>(LDllNames, 'libeay32.dll') >= 0,
+    'libeay32.dll must be detected when LIBEAY_DLL_NAME is declared in one ' +
+    'unit and GetModuleHandle is called in another');
 end;
 
 initialization

--- a/tests/DX.Comply.Tests.Engine.pas
+++ b/tests/DX.Comply.Tests.Engine.pas
@@ -166,6 +166,27 @@ type
     /// </summary>
     [Test]
     procedure Generate_ValidProject_ContainsExternalDllComponents;
+
+    // ---- ScanPasFilesForDllReferences (issue #24 regressions) ---------------
+
+    /// <summary>const NAME = 'foo.dll' + LoadLibrary(NAME) must resolve to foo.dll.</summary>
+    [Test]
+    procedure ScanPasFiles_ConstAndLoadLibrary_ResolvesDllName;
+
+    /// <summary>GetModuleHandle('foo.dll') must be detected.</summary>
+    [Test]
+    procedure ScanPasFiles_GetModuleHandle_DetectsDllName;
+
+    /// <summary>
+    /// Same const name in two different units must each resolve independently
+    /// (no cross-unit collision).
+    /// </summary>
+    [Test]
+    procedure ScanPasFiles_SameConstInTwoUnits_BothResolveCorrectly;
+
+    /// <summary>A comparison like `if X = 'foo.dll'` must NOT be parsed as a const.</summary>
+    [Test]
+    procedure ScanPasFiles_ComparisonExpression_NotTreatedAsConst;
   end;
 
 implementation
@@ -825,6 +846,125 @@ begin
   finally
     LGen.Free;
   end;
+end;
+
+// ---- ScanPasFilesForDllReferences (issue #24) ------------------------------
+
+procedure TEngineTests.ScanPasFiles_ConstAndLoadLibrary_ResolvesDllName;
+var
+  LPasFile: string;
+  LDllNames: TArray<string>;
+const
+  cSource =
+    'unit TestUnitA;'#13#10 +
+    'interface'#13#10 +
+    'const'#13#10 +
+    '  LIBEAY_DLL_NAME = ''libeay32.dll'';'#13#10 +
+    'implementation'#13#10 +
+    'procedure DoIt;'#13#10 +
+    'begin'#13#10 +
+    '  LoadLibrary(LIBEAY_DLL_NAME);'#13#10 +
+    'end;'#13#10 +
+    'end.';
+begin
+  LPasFile := TPath.Combine(FTempDir, 'TestUnitA.pas');
+  TFile.WriteAllText(LPasFile, cSource, TEncoding.UTF8);
+  LDllNames := TDxComplyGenerator.ScanPasFilesForDllReferences(
+    TArray<string>.Create(LPasFile));
+  Assert.IsTrue(TArray.IndexOf<string>(LDllNames, 'libeay32.dll') >= 0,
+    'libeay32.dll must be detected through const + LoadLibrary identifier resolution');
+end;
+
+procedure TEngineTests.ScanPasFiles_GetModuleHandle_DetectsDllName;
+var
+  LPasFile: string;
+  LDllNames: TArray<string>;
+const
+  cSource =
+    'unit TestUnitGmh;'#13#10 +
+    'interface'#13#10 +
+    'implementation'#13#10 +
+    'procedure DoIt;'#13#10 +
+    'begin'#13#10 +
+    '  GetModuleHandle(''user32.dll'');'#13#10 +
+    'end;'#13#10 +
+    'end.';
+begin
+  LPasFile := TPath.Combine(FTempDir, 'TestUnitGmh.pas');
+  TFile.WriteAllText(LPasFile, cSource, TEncoding.UTF8);
+  LDllNames := TDxComplyGenerator.ScanPasFilesForDllReferences(
+    TArray<string>.Create(LPasFile));
+  Assert.IsTrue(TArray.IndexOf<string>(LDllNames, 'user32.dll') >= 0,
+    'GetModuleHandle with a literal argument must be detected');
+end;
+
+procedure TEngineTests.ScanPasFiles_SameConstInTwoUnits_BothResolveCorrectly;
+var
+  LPasFile1, LPasFile2: string;
+  LDllNames: TArray<string>;
+const
+  cSourceA =
+    'unit UnitAlpha;'#13#10 +
+    'interface'#13#10 +
+    'const'#13#10 +
+    '  DLL_NAME = ''alpha.dll'';'#13#10 +
+    'implementation'#13#10 +
+    'procedure DoIt;'#13#10 +
+    'begin'#13#10 +
+    '  LoadLibrary(DLL_NAME);'#13#10 +
+    'end;'#13#10 +
+    'end.';
+  cSourceB =
+    'unit UnitBeta;'#13#10 +
+    'interface'#13#10 +
+    'const'#13#10 +
+    '  DLL_NAME = ''beta.dll'';'#13#10 +
+    'implementation'#13#10 +
+    'procedure DoIt;'#13#10 +
+    'begin'#13#10 +
+    '  LoadLibrary(DLL_NAME);'#13#10 +
+    'end;'#13#10 +
+    'end.';
+begin
+  LPasFile1 := TPath.Combine(FTempDir, 'UnitAlpha.pas');
+  LPasFile2 := TPath.Combine(FTempDir, 'UnitBeta.pas');
+  TFile.WriteAllText(LPasFile1, cSourceA, TEncoding.UTF8);
+  TFile.WriteAllText(LPasFile2, cSourceB, TEncoding.UTF8);
+
+  LDllNames := TDxComplyGenerator.ScanPasFilesForDllReferences(
+    TArray<string>.Create(LPasFile1, LPasFile2));
+
+  Assert.IsTrue(TArray.IndexOf<string>(LDllNames, 'alpha.dll') >= 0,
+    'alpha.dll (UnitAlpha.DLL_NAME) must resolve independently');
+  Assert.IsTrue(TArray.IndexOf<string>(LDllNames, 'beta.dll') >= 0,
+    'beta.dll (UnitBeta.DLL_NAME) must resolve independently');
+end;
+
+procedure TEngineTests.ScanPasFiles_ComparisonExpression_NotTreatedAsConst;
+var
+  LPasFile: string;
+  LDllNames: TArray<string>;
+const
+  cSource =
+    'unit TestCmp;'#13#10 +
+    'interface'#13#10 +
+    'implementation'#13#10 +
+    'procedure DoIt;'#13#10 +
+    'var X: string;'#13#10 +
+    'begin'#13#10 +
+    '  X := SomeFunc;'#13#10 +
+    '  if X = ''foo.dll'' then'#13#10 +
+    '    LoadLibrary(X);'#13#10 +
+    'end;'#13#10 +
+    'end.';
+begin
+  LPasFile := TPath.Combine(FTempDir, 'TestCmp.pas');
+  TFile.WriteAllText(LPasFile, cSource, TEncoding.UTF8);
+  LDllNames := TDxComplyGenerator.ScanPasFilesForDllReferences(
+    TArray<string>.Create(LPasFile));
+  Assert.IsTrue(TArray.IndexOf<string>(LDllNames, 'foo.dll') < 0,
+    '`if X = ''foo.dll''` must NOT be parsed as a const declaration; ' +
+    'foo.dll should not appear in detected DLLs');
 end;
 
 initialization


### PR DESCRIPTION
## Summary

Fixes #24 — external DLL detection only matched string literals passed to a small set of loaders. The common Delphi idiom of declaring the file name once as a const and passing the identifier was missed:

\`\`\`pascal
const
  LIBEAY_DLL_NAME = 'libeay32.dll';
  IBASE_DLL = 'gds32.dll';

hLibeayDLL := GetModuleHandle(LIBEAY_DLL_NAME);  // not detected before
Gds32 := Windows.LoadLibrary(IBASE_DLL);          // not detected before
\`\`\`

Detection now:
1. Recognises `GetModuleHandle(A/W)`, `LoadLibraryA/W` and `LoadPackage` in addition to `LoadLibrary` / `LoadLibraryEx` / `SafeLoadLibrary`.
2. Builds a unit-wide map of `const NAME = 'something.dll';` declarations in a first pass.
3. Resolves identifier-form loader calls against that map in a second pass, so order of declaration within the unit does not matter.

Quoted-literal references continue to work as before; the const map is only consulted for identifier arguments.

## Files changed
- `src/DX.Comply.Engine.pas` — `AddExternalDllReferencesToArtefacts`.

## Test plan
- [ ] Build & generate SBOM for a project that uses `const LIBEAY_DLL_NAME = 'libeay32.dll';` plus `LoadLibrary(LIBEAY_DLL_NAME)`; verify `libeay32.dll` appears in the SBOM/HTML.
- [ ] Same for `GetModuleHandle(LIBEAY_DLL_NAME)`.
- [ ] Confirm existing literal cases still pass (`external 'netapi32.dll'`).
- [ ] No duplicate entries when both literal and identifier forms reference the same DLL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)