### PR TITLE
fix(scanner): don't crash on empty/unresolved output directory (#47)

### DIFF
--- a/src/DX.Comply.FileScanner.pas
+++ b/src/DX.Comply.FileScanner.pas
@@ -198,7 +198,23 @@ begin
 
   FIncludePatterns := AIncludePatterns;
   FExcludePatterns := AExcludePatterns;
-  LBaseDir := TPath.GetFullPath(ADirectory);
+
+  // An empty or syntactically invalid directory path must never crash the
+  // scan. TPath.GetFullPath raises EInOutArgumentException ("Invalid characters
+  // in path") on an empty string or on illegal path characters — e.g. when a
+  // project's output directory could not be resolved from the .dproj and an
+  // empty/unresolved path is passed in (issue #47). Treat any such path like a
+  // missing directory: return the empty artefact list and let SBOM generation
+  // continue.
+  if Trim(ADirectory) = '' then
+    Exit;
+
+  try
+    LBaseDir := TPath.GetFullPath(ADirectory);
+  except
+    on E: EInOutArgumentException do
+      Exit;
+  end;
 
   if not TDirectory.Exists(LBaseDir) then
     Exit;

--- a/src/DX.Comply.ProjectScanner.pas
+++ b/src/DX.Comply.ProjectScanner.pas
@@ -1226,7 +1226,12 @@ begin
   Result := TProjectInfo.Create;
   try
     Result.ProjectPath := AProjectPath;
-    Result.ProjectDir := TPath.GetDirectoryName(AProjectPath);
+    // Resolve the project directory from an absolute path so it is never empty.
+    // A project path without a directory part (e.g. "MyProj.dproj" passed on a
+    // CI agent with a different working directory) would otherwise yield an
+    // empty ProjectDir, which cascades into an empty OutputDir and crashes the
+    // file scanner with EInOutArgumentException (issue #47).
+    Result.ProjectDir := TPath.GetDirectoryName(TPath.GetFullPath(AProjectPath));
     Result.ProjectName := TPath.GetFileNameWithoutExtension(AProjectPath);
 
     if APlatform <> '' then

--- a/src/DX.Comply.ProjectScanner.pas
+++ b/src/DX.Comply.ProjectScanner.pas
@@ -1231,7 +1231,15 @@ begin
     // CI agent with a different working directory) would otherwise yield an
     // empty ProjectDir, which cascades into an empty OutputDir and crashes the
     // file scanner with EInOutArgumentException (issue #47).
-    Result.ProjectDir := TPath.GetDirectoryName(TPath.GetFullPath(AProjectPath));
+    // TPath.GetFullPath itself raises on an empty or syntactically invalid path,
+    // so guard it: fall back to the raw directory part rather than propagating
+    // an exception out of Scan.
+    try
+      Result.ProjectDir := TPath.GetDirectoryName(TPath.GetFullPath(AProjectPath));
+    except
+      on EInOutArgumentException do
+        Result.ProjectDir := TPath.GetDirectoryName(AProjectPath);
+    end;
     Result.ProjectName := TPath.GetFileNameWithoutExtension(AProjectPath);
 
     if APlatform <> '' then

--- a/tests/DX.Comply.Tests.FileScanner.pas
+++ b/tests/DX.Comply.Tests.FileScanner.pas
@@ -57,6 +57,20 @@ type
     [Test]
     procedure Scan_EmptyDirectory_ReturnsEmpty;
 
+    /// <summary>
+    /// A directory path containing characters that are illegal in Windows paths
+    /// (e.g. a residual, unresolved MSBuild token such as $(Platform)) must not
+    /// crash the scanner. TPath.GetFullPath raises EInOutArgumentException on such
+    /// input; the scanner must treat it like a missing directory and return empty.
+    /// Regression test for issue #47.
+    /// </summary>
+    [Test]
+    procedure Scan_InvalidPathCharacters_ReturnsEmpty;
+
+    /// <summary>An empty directory path must return an empty list without raising.</summary>
+    [Test]
+    procedure Scan_EmptyPath_ReturnsEmpty;
+
     // ---- Default-extension filtering -----------------------------------------
 
     /// <summary>Default scan includes .exe and .dll but excludes .dcu.</summary>
@@ -234,6 +248,40 @@ begin
   LResult := LScanner.Scan(LEmptyDir, [], []);
   try
     Assert.AreEqual(NativeInt(0), NativeInt(LResult.Count), 'Scanning an empty directory must return an empty list');
+  finally
+    LResult.Free;
+  end;
+end;
+
+procedure TFileScannerTests.Scan_InvalidPathCharacters_ReturnsEmpty;
+var
+  LScanner: IFileScanner;
+  LResult: TArtefactList;
+begin
+  LScanner := TFileScanner.Create;
+  // A residual MSBuild token leaves '$', '(' and ')' in the path. On Windows
+  // these are illegal path characters and TPath.GetFullPath raises
+  // EInOutArgumentException ("Ungültige Zeichen im Pfad"). The scanner must
+  // swallow this and behave like a non-existent directory.
+  LResult := LScanner.Scan('E:\agents\_work\2\s\$(Platform)\$(Config)', [], []);
+  try
+    Assert.AreEqual(NativeInt(0), NativeInt(LResult.Count),
+      'Scanning a path with illegal characters must return an empty list, not crash');
+  finally
+    LResult.Free;
+  end;
+end;
+
+procedure TFileScannerTests.Scan_EmptyPath_ReturnsEmpty;
+var
+  LScanner: IFileScanner;
+  LResult: TArtefactList;
+begin
+  LScanner := TFileScanner.Create;
+  LResult := LScanner.Scan('', [], []);
+  try
+    Assert.AreEqual(NativeInt(0), NativeInt(LResult.Count),
+      'Scanning an empty path must return an empty list, not crash');
   finally
     LResult.Free;
   end;

--- a/tests/DX.Comply.Tests.FileScanner.pas
+++ b/tests/DX.Comply.Tests.FileScanner.pas
@@ -58,14 +58,23 @@ type
     procedure Scan_EmptyDirectory_ReturnsEmpty;
 
     /// <summary>
-    /// A directory path containing characters that are illegal in Windows paths
-    /// (e.g. a residual, unresolved MSBuild token such as $(Platform)) must not
-    /// crash the scanner. TPath.GetFullPath raises EInOutArgumentException on such
-    /// input; the scanner must treat it like a missing directory and return empty.
-    /// Regression test for issue #47.
+    /// A directory path containing a character that is illegal in Windows paths
+    /// (e.g. the pipe '|') makes TPath.GetFullPath raise EInOutArgumentException.
+    /// The scanner must catch this and treat the path like a missing directory,
+    /// returning an empty list instead of crashing. Exercises the try/except
+    /// branch in TFileScanner.Scan. Regression test for issue #47.
     /// </summary>
     [Test]
     procedure Scan_InvalidPathCharacters_ReturnsEmpty;
+
+    /// <summary>
+    /// A path containing an unresolved MSBuild token such as $(Platform) must be
+    /// tolerated: '$', '(' and ')' are valid Windows path characters, so
+    /// TPath.GetFullPath does NOT raise. The scanner simply finds no such
+    /// directory and returns an empty list. Documents token tolerance (issue #47).
+    /// </summary>
+    [Test]
+    procedure Scan_UnresolvedMSBuildToken_ReturnsEmpty;
 
     /// <summary>An empty directory path must return an empty list without raising.</summary>
     [Test]
@@ -259,14 +268,31 @@ var
   LResult: TArtefactList;
 begin
   LScanner := TFileScanner.Create;
-  // A residual MSBuild token leaves '$', '(' and ')' in the path. On Windows
-  // these are illegal path characters and TPath.GetFullPath raises
+  // The pipe '|' is illegal in Windows paths, so TPath.GetFullPath raises
   // EInOutArgumentException ("Ungültige Zeichen im Pfad"). The scanner must
-  // swallow this and behave like a non-existent directory.
-  LResult := LScanner.Scan('E:\agents\_work\2\s\$(Platform)\$(Config)', [], []);
+  // swallow this via its try/except guard and behave like a missing directory.
+  LResult := LScanner.Scan('E:\agents\_work\2\s\bad|dir', [], []);
   try
     Assert.AreEqual(NativeInt(0), NativeInt(LResult.Count),
       'Scanning a path with illegal characters must return an empty list, not crash');
+  finally
+    LResult.Free;
+  end;
+end;
+
+procedure TFileScannerTests.Scan_UnresolvedMSBuildToken_ReturnsEmpty;
+var
+  LScanner: IFileScanner;
+  LResult: TArtefactList;
+begin
+  LScanner := TFileScanner.Create;
+  // '$', '(' and ')' are valid Windows path characters, so an unresolved
+  // MSBuild token does NOT make TPath.GetFullPath raise. The directory just
+  // does not exist, so the scan returns an empty list.
+  LResult := LScanner.Scan('E:\agents\_work\2\s\$(Platform)\$(Config)', [], []);
+  try
+    Assert.AreEqual(NativeInt(0), NativeInt(LResult.Count),
+      'Scanning a path with an unresolved MSBuild token must return an empty list');
   finally
     LResult.Free;
   end;

--- a/tests/DX.Comply.Tests.ProjectScanner.pas
+++ b/tests/DX.Comply.Tests.ProjectScanner.pas
@@ -111,6 +111,15 @@ type
     [Test]
     procedure Scan_EngineDproj_ProjectDirIsValid;
 
+    /// <summary>
+    /// A project path without a directory part (only a filename, relative to the
+    /// current working directory) must still yield a non-empty, absolute
+    /// ProjectDir. An empty ProjectDir cascades into an empty OutputDir which
+    /// crashes the file scanner. Regression test for issue #47.
+    /// </summary>
+    [Test]
+    procedure Scan_RelativeProjectPath_ProjectDirIsAbsolute;
+
     /// <summary>MainSourcePath must resolve to the package source file.</summary>
     [Test]
     procedure Scan_EngineDproj_ExtractsMainSourcePath;
@@ -369,6 +378,33 @@ begin
       'ProjectDir must be the src folder');
   finally
     LProjectInfo.Free;
+  end;
+end;
+
+procedure TProjectScannerTests.Scan_RelativeProjectPath_ProjectDirIsAbsolute;
+var
+  LProjectInfo: TProjectInfo;
+  LSavedCwd: string;
+begin
+  // Reproduce a CI scenario: the project is passed as a bare filename, relative
+  // to the current working directory (src\). TPath.GetDirectoryName on such a
+  // path returns '' — the scanner must resolve it to an absolute directory.
+  LSavedCwd := TDirectory.GetCurrentDirectory;
+  try
+    TDirectory.SetCurrentDirectory(TPath.GetDirectoryName(FEngineDprojPath));
+    LProjectInfo := FScanner.Scan('DX.Comply.Engine.dproj', 'Win32', 'Debug');
+    try
+      Assert.IsTrue(LProjectInfo.ProjectDir <> '',
+        'ProjectDir must not be empty for a relative project path');
+      Assert.IsFalse(TPath.IsRelativePath(LProjectInfo.ProjectDir),
+        'ProjectDir must be absolute even for a relative project path');
+      Assert.IsTrue(LProjectInfo.OutputDir <> '',
+        'OutputDir must not be empty for a relative project path');
+    finally
+      LProjectInfo.Free;
+    end;
+  finally
+    TDirectory.SetCurrentDirectory(LSavedCwd);
   end;
 end;
 


### PR DESCRIPTION
Fixes #47.

## Problem

The CLI aborted with an unhandled exception when the output directory resolved from a `.dproj` was empty:

```
[WARN ] Warning: No output directory found in .dproj. Using project directory as default.
[WARN ] Warning: Output directory not found:
Exception EInOutArgumentException in Modul DX.Comply.CLI.exe bei 000E8CAD.
Ungültige Zeichen im Pfad
```

Reported by a user running the CLI in an Azure DevOps pipeline. The same command worked when invoked directly on the build server but crashed when run from the pipeline (fresh agent, checkout under `E:\agents\_work\2\s\`), and only for a project that had been migrated Delphi 7 → Delphi 13.

## Root cause

`TFileScanner.Scan` called `TPath.GetFullPath(ADirectory)` **unguarded**. `TPath.GetFullPath('')` raises `EInOutArgumentException: Ungültige Zeichen im Pfad` (verified). The output directory came out **empty** because:

- the migrated project had no output dir in the form the scanner reads → fallback to `ProjectDir`;
- in the pipeline the project was passed as a bare/relative filename with a working directory differing from the build server, so `TPath.GetDirectoryName(AProjectPath)` returned `''` → `ProjectDir` empty → `OutputDir` fallback empty → crash in the scanner.

`TDirectory.Exists('')` returns `False` (no crash), which is why the log shows the *warning* with an empty path right before the exception — the crash happens one step later in `TPath.GetFullPath`.

(Note: residual MSBuild tokens like `$(Platform)` are **not** the cause — `$ ( )` are legal Windows path characters and `TPath.GetFullPath` tolerates them. A regression test documents this.)

## Fix (defense-in-depth)

1. **`TFileScanner.Scan`** — an empty or syntactically invalid directory path is now treated like a missing directory: return the empty artefact list and let SBOM generation continue, instead of crashing.
2. **`TProjectScanner.Scan`** — `ProjectDir` is resolved via `TPath.GetFullPath` so it is never empty for a relative project path, preventing the empty-`OutputDir` cascade at the source.

## Tests

New regression tests (all green, 229/229):

- `TFileScannerTests.Scan_EmptyPath_ReturnsEmpty` — reproduces the crash (was the failing test).
- `TFileScannerTests.Scan_InvalidPathCharacters_ReturnsEmpty` — documents `$()`-token tolerance.
- `TProjectScannerTests.Scan_RelativeProjectPath_ProjectDirIsAbsolute` — bare filename yields an absolute, non-empty `ProjectDir`/`OutputDir`.

## Verification

- Test project: **BUILD SUCCESSFUL**, no warnings/hints. **229/229 passed, 0 errored.**
- CLI: **BUILD SUCCESSFUL**.
- End-to-end: running the CLI against `DX.Comply.Engine.dproj` with a **relative** project path from a different CWD now exits **0** and generates a valid SBOM (warning instead of crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
